### PR TITLE
Add option to hide event items, but show which days have them.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-simple-calendar",
-  "version": "4.3.0",
+  "version": "4.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -924,9 +924,9 @@
       "dev": true
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
       "dev": true
     },
     "@hapi/joi": {
@@ -1622,9 +1622,9 @@
       }
     },
     "acorn": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -6115,13 +6115,13 @@
       }
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+      "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.12",
         "minimatch": "~3.0.2"
       }
     },
@@ -6903,13 +6903,10 @@
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -7109,9 +7106,9 @@
       }
     },
     "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
       "dev": true
     },
     "js-levenshtein": {
@@ -7234,9 +7231,9 @@
       "dev": true
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "launch-editor": {
@@ -8097,9 +8094,9 @@
       }
     },
     "node-sass": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
-      "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -10409,9 +10406,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.0.tgz",
-      "integrity": "sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "serve-index": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"eslint-config-tabsanity": "^1.0.22",
 		"eslint-plugin-prettier": "^3.1.1",
 		"eslint-plugin-vue": "^5.0.0",
-		"node-sass": "^4.13.0",
+		"node-sass": "^4.13.1",
 		"prettier": "^1.18.2",
 		"sass-loader": "^7.3.1",
 		"vue-template-compiler": "^2.6.10"

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -58,6 +58,7 @@
 							lastInstance: isLastInstanceOfMonth(day),
 						},
 						...((dateClasses && dateClasses[isoYearMonthDay(day)]) || null),
+						hasEvent(day)
 					]"
 					@click="onClickDay(day, findAndSortItemsInDay(day))"
 					@drop.prevent="onDrop(day, $event)"
@@ -429,6 +430,13 @@ export default {
 		// ******************************
 		// Calendar Items
 		// ******************************
+
+		hasEvent(day) {
+			if(this.findAndSortItemsInDay(day).length > 0)
+				return "hasEvent"
+			else
+				return ""
+		},
 
 		sortItemCallback(a, b) {
 			if (a.startDate < b.startDate) return -1

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -69,7 +69,7 @@
 					<slot :day="day" name="dayContent" />
 				</div>
 				<template v-for="e in getWeekItems(weekStart)">
-					<slot
+					<slot v-if="showEvents"
 						:event="e"
 						:weekStartDate="weekStart"
 						:top="getItemTop(e)"
@@ -117,6 +117,7 @@ export default {
 		enableDragDrop: { type: Boolean, default: false },
 		startingDayOfWeek: { type: Number, default: 0 },
 		events: { type: Array, default: () => [] },
+		showEvents: { type: Boolean, default: true },
 		dateClasses: { type: Object, default: () => {} },
 		eventTop: { type: String, default: "1.4em" },
 		eventContentHeight: { type: String, default: "1.4em" },


### PR DESCRIPTION
For our use case we actually didn't want the events themselves to show on the calendar, but to have a background color on the days themselves that had events and on clicking the day the events would be revealed in a list below the calendar. This adds that option using the boolean prop showEvents and the class hasEvent added to days that have a least one event.

If there is a better way to go about this I'd appreciate the feedback as I am still learning Vue.

I also updated the packages through an audit to fix any vulnerabilities. 